### PR TITLE
fix: ITU-R BS.1770 compliant K-weighting filter implementation

### DIFF
--- a/src/level_calc.cpp
+++ b/src/level_calc.cpp
@@ -53,8 +53,7 @@ void LevelCalc::setChannels(size_t channels) {
 
 void LevelCalc::initFiltersIfNeeded(size_t channels) {
     shelfFilters_.resize(channels);
-    hp1Filters_.resize(channels);
-    hp2Filters_.resize(channels);
+    hpFilters_.resize(channels);
 }
 
 void LevelCalc::resetBlockAccumulators() {
@@ -77,41 +76,49 @@ void LevelCalc::updateFilterCoeffs() {
     uint32_t fs = sampleRate_.load(std::memory_order_relaxed);
     if (fs == 0 || channels_ == 0) return;
 
-    // 1st-order HP 2段 @60 Hz
-    const float fc_hp = 60.f;
-    float K = static_cast<float>(fs) / (static_cast<float>(M_PI) * fc_hp);
-    float b0_hp = K / (K + 1.0f);
-    float b1_hp = -b0_hp;
-    float a1_hp = (1.0f - K) / (1.0f + K);
-    for (size_t ch = 0; ch < channels_; ++ch) {
-        hp1Filters_[ch].setCoeffs(b0_hp, b1_hp, a1_hp);
-        hp2Filters_[ch].setCoeffs(b0_hp, b1_hp, a1_hp);
-        hp1Filters_[ch].reset();
-        hp2Filters_[ch].reset();
+    // ITU-R BS.1770 stage 1: high-shelf pre-filter (+4 dB @ ~1.7 kHz)
+    {
+        const double f0 = 1681.974450955533;
+        const double G  = 3.999843853973347;
+        const double Q  = 0.7071752369554193;
+        double K  = std::tan(M_PI * f0 / static_cast<double>(fs));
+        double Vh = std::pow(10.0, G / 20.0);
+        double Vb = std::pow(Vh, 0.4996667741545416);
+        double a0 = 1.0 + K / Q + K * K;
+        float sb0 = static_cast<float>((Vh + Vb * K / Q + K * K) / a0);
+        float sb1 = static_cast<float>(2.0 * (K * K - Vh) / a0);
+        float sb2 = static_cast<float>((Vh - Vb * K / Q + K * K) / a0);
+        float sa1 = static_cast<float>(2.0 * (K * K - 1.0) / a0);
+        float sa2 = static_cast<float>((1.0 - K / Q + K * K) / a0);
+        for (size_t ch = 0; ch < channels_; ++ch) {
+            shelfFilters_[ch].b0 = sb0;
+            shelfFilters_[ch].b1 = sb1;
+            shelfFilters_[ch].b2 = sb2;
+            shelfFilters_[ch].a1 = sa1;
+            shelfFilters_[ch].a2 = sa2;
+            shelfFilters_[ch].reset();
+        }
     }
 
-    // High-shelf +4 dB @ ~1.7kHz
-    const float gainDb = 4.0f;
-    const float f0 = 1681.974f;
-    float A = std::sqrt(std::pow(10.0f, gainDb / 20.0f));
-    float w0 = 2.0f * static_cast<float>(M_PI) * f0 / static_cast<float>(fs);
-    float cw = std::cos(w0);
-    float sw = std::sin(w0);
-    float alpha = sw * std::sqrt(2.0f) * 0.5f;
-    float a0 = (A + 1.0f) - (A - 1.0f) * cw + 2.0f * std::sqrt(A) * alpha;
-    float b0 = A * ((A + 1.0f) + (A - 1.0f) * cw + 2.0f * std::sqrt(A) * alpha) / a0;
-    float b1 = -2.0f * A * ((A - 1.0f) + (A + 1.0f) * cw) / a0;
-    float b2 = A * ((A + 1.0f) + (A - 1.0f) * cw - 2.0f * std::sqrt(A) * alpha) / a0;
-    float a1 =  2.0f * ((A - 1.0f) - (A + 1.0f) * cw) / a0;
-    float a2 = ((A + 1.0f) - (A - 1.0f) * cw - 2.0f * std::sqrt(A) * alpha) / a0;
-
-    for (size_t ch = 0; ch < channels_; ++ch) {
-        shelfFilters_[ch].b0 = b0;
-        shelfFilters_[ch].b1 = b1;
-        shelfFilters_[ch].b2 = b2;
-        shelfFilters_[ch].a1 = a1;
-        shelfFilters_[ch].a2 = a2;
-        shelfFilters_[ch].reset();
+    // ITU-R BS.1770 stage 2: 2nd-order Butterworth high-pass @ 38.135 Hz
+    {
+        const double f0 = 38.13547087602444;
+        const double Q  = 0.5003270373238773;
+        double K  = std::tan(M_PI * f0 / static_cast<double>(fs));
+        double a0 = 1.0 + K / Q + K * K;
+        float hb0 = static_cast<float>(1.0 / a0);
+        float hb1 = static_cast<float>(-2.0 / a0);
+        float hb2 = static_cast<float>(1.0 / a0);
+        float ha1 = static_cast<float>(2.0 * (K * K - 1.0) / a0);
+        float ha2 = static_cast<float>((1.0 - K / Q + K * K) / a0);
+        for (size_t ch = 0; ch < channels_; ++ch) {
+            hpFilters_[ch].b0 = hb0;
+            hpFilters_[ch].b1 = hb1;
+            hpFilters_[ch].b2 = hb2;
+            hpFilters_[ch].a1 = ha1;
+            hpFilters_[ch].a2 = ha2;
+            hpFilters_[ch].reset();
+        }
     }
 }
 
@@ -145,8 +152,7 @@ void LevelCalc::process(float **data, uint32_t frames, size_t channels) {
             sumSqrPerCh[ch] += static_cast<double>(s) * static_cast<double>(s);
 
             // K-weighting
-            float y = hp1Filters_[ch].process(s);
-            y = hp2Filters_[ch].process(y);
+            float y = hpFilters_[ch].process(s);
             float y2 = shelfFilters_[ch].process(y);
 
             if (ch < sumSquaresHop_.size())

--- a/src/level_calc.h
+++ b/src/level_calc.h
@@ -68,19 +68,8 @@ private:
     std::atomic<uint32_t> sampleRate_;
     size_t channels_ = 0;
 
-    // K-weighting フィルタ
-    struct FirstOrderHP {
-        float b0 = 0.f, b1 = 0.f, a1 = 0.f;
-        float x1 = 0.f, y1 = 0.f;
-        void setCoeffs(float b0_, float b1_, float a1_) { b0 = b0_; b1 = b1_; a1 = a1_; }
-        inline float process(float x) {
-            float y = b0 * x + b1 * x1 - a1 * y1;
-            x1 = x; y1 = y;
-            return y;
-        }
-        void reset() { x1 = 0.f; y1 = 0.f; }
-    };
-    struct BiquadHS {
+    // K-weighting フィルタ (ITU-R BS.1770 stage 1: high-shelf, stage 2: high-pass)
+    struct Biquad {
         float b0 = 1.f, b1 = 0.f, b2 = 0.f, a1 = 0.f, a2 = 0.f;
         float x1 = 0.f, x2 = 0.f, y1 = 0.f, y2 = 0.f;
         inline float process(float x) {
@@ -90,9 +79,8 @@ private:
         }
         void reset() { x1 = x2 = y1 = y2 = 0.f; }
     };
-    std::vector<BiquadHS> shelfFilters_;
-    std::vector<FirstOrderHP> hp1Filters_;
-    std::vector<FirstOrderHP> hp2Filters_;
+    std::vector<Biquad> shelfFilters_;
+    std::vector<Biquad> hpFilters_;
 
     // 100ms hop / 400ms window
     uint32_t hopSamples_ = 0;


### PR DESCRIPTION
## 概要 (Summary)

K-weighting フィルタがITU-R BS.1770 (EBU R128) に準拠していないため、LUFSの算出値がズレていた問題を修正します。

This PR fixes incorrect LUFS readings caused by K-weighting filters that did not conform to ITU-R BS.1770 (EBU R128).

---

## 課題 (Problem)

| | 変更前 (Before) | BS.1770規定 (BS.1770 spec) |
|---|---|---|
| ハイシェルフ (High-shelf) | `w0 = 2πf/fs` (Audio EQ Cookbook)  | `K = tan(πf/fs)` (bilinear K) |
| ハイパス (High-pass) | 1st order IIR × 2 stages, fc = 60 Hz | 2nd Butterworth, fc = 38.135 Hz |

---

## 変更内容 (Changes)

**`src/level_calc.cpp`** — `updateFilterCoeffs()`

- ハイシェルフフィルタの設計を bilinear K 変換式に置き換え、BS.1770 規定パラメータ (f0 = 1681.974Hz, G=3.9998dB, Q = 0.7072) を使用します
- ハイパスフィルタを 2 次 Butterworth (fc = 38.135Hz, Q = 0.5003) 1 段に置き換えました
- 変数スコープ分離のため各ブロックを `{}` で囲んでいます

**`src/level_calc.h`**

- `FirstOrderHP` は削除して `Biquad` 1 つに統合しました

**全体**

- `hp1Filters_`, `hp2Filters_` を `hpFilters_` (単段) に統合しました


## テスト (Test)

- ffmpeg で生成したファイル (50kHz 正弦波) をメディアソースで再生して測定値を確認しました。

```
# モノラルで出力すると 2 チャンネルに同じ信号が複製されて再生され +3dB になる挙動だったのでステレオで作成
ffmpeg -f lavfi -i "sine=frequency=50:sample_rate=48000:duration=300" -af "pan=stereo|c0=c0|c1=c0" sine-50.wav

# Integrated loudness を確認
ffmpeg -nostats -i sine-50.wav -filter_complex ebur128 -f null -
...
[Parsed_ebur128_0 @ 000001e51a0fc900] Summary:

  Integrated loudness:
    I:         -22.7 LUFS
    Threshold: -32.7 LUFS

  Loudness range:
    LRA:         0.0 LU
    Threshold: -42.7 LUFS
    LRA low:   -22.7 LUFS
    LRA high:  -22.7 LUFS
...
```
<img width="470" height="624" alt="image" src="https://github.com/user-attachments/assets/3ab4d9dd-992d-4ca4-ab9d-ffdf247f463c" />

- ランダムなソースを再生しながら他のラウドネスメーターも同時に使用して全体的に測定値が一致していることを確認しました